### PR TITLE
Fix quotes in README_patch_modul_9

### DIFF
--- a/README_patch_modul_9.md
+++ b/README_patch_modul_9.md
@@ -5,7 +5,7 @@ Ova zakrpa dodaje **MODUL 9 – Traženje poslova** u vaš `app.py` bez ručnog 
 ---
 
 ## 🛠️ Što sadrži zakrpa:
-- Dodaje gumb **“🔍 Traženje poslova”** u početni izbornik
+ - Dodaje gumb **"🔍 Traženje poslova"** u početni izbornik
 - Poziva funkciju `prikazi_modul_9()` unutar `render_module()`
 - Pretpostavlja da postoji datoteka `modul_9_trazenje_poslova.py` s tom funkcijom
 


### PR DESCRIPTION
## Summary
- replace curly quotes in README_patch_modul_9 with standard double quotes

## Testing
- `pip install markdown` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68821589b1a88322a6584920e90975a3